### PR TITLE
add summary quantile label support, and with default precision

### DIFF
--- a/core/include/prometheus/client_metric.h
+++ b/core/include/prometheus/client_metric.h
@@ -43,7 +43,7 @@ struct PROMETHEUS_CPP_CORE_EXPORT ClientMetric {
   // Summary
 
   struct Quantile {
-    double quantile = 0.0;
+    std::string quantile = "0.0";
     double value = 0.0;
   };
 

--- a/core/include/prometheus/detail/ckms_quantiles.h
+++ b/core/include/prometheus/detail/ckms_quantiles.h
@@ -17,8 +17,10 @@ class PROMETHEUS_CPP_CORE_EXPORT CKMSQuantiles {
     const double error;
     const double u;
     const double v;
+    std::string name = "";
 
     Quantile(double quantile, double error);
+    Quantile(double quantile, double error, const std::string& name);
   };
 
  private:

--- a/core/src/detail/ckms_quantiles.cc
+++ b/core/src/detail/ckms_quantiles.cc
@@ -12,7 +12,13 @@ CKMSQuantiles::Quantile::Quantile(double quantile, double error)
       error(error),
       u(2.0 * error / (1.0 - quantile)),
       v(2.0 * error / quantile) {}
-
+CKMSQuantiles::Quantile::Quantile(double quantile, double error,
+                                  const std::string& name)
+    : quantile(quantile),
+      error(error),
+      u(2.0 * error / (1.0 - quantile)),
+      v(2.0 * error / quantile),
+      name(name) {}
 CKMSQuantiles::Item::Item(double value, int lower_delta, int delta)
     : value(value), g(lower_delta), delta(delta) {}
 

--- a/core/src/summary.cc
+++ b/core/src/summary.cc
@@ -1,5 +1,8 @@
 #include "prometheus/summary.h"
 
+#include <iomanip>
+#include <sstream>
+
 namespace prometheus {
 
 Summary::Summary(const Quantiles& quantiles,
@@ -24,7 +27,14 @@ ClientMetric Summary::Collect() const {
 
   for (const auto& quantile : quantiles_) {
     auto metricQuantile = ClientMetric::Quantile{};
-    metricQuantile.quantile = quantile.quantile;
+    if (quantile.name.empty()) {
+      std::stringstream stream;
+      stream << std::fixed << quantile.quantile;
+      metricQuantile.quantile = stream.str();
+    } else {
+      metricQuantile.quantile = quantile.name;
+    }
+
     metricQuantile.value = quantile_values_.get(quantile.quantile);
     metric.summary.quantile.push_back(std::move(metricQuantile));
   }

--- a/core/tests/summary_test.cc
+++ b/core/tests/summary_test.cc
@@ -43,13 +43,15 @@ TEST(SummaryTest, quantile_size) {
 }
 
 TEST(SummaryTest, quantile_bounds) {
-  Summary summary{Summary::Quantiles{{0.5, 0.05}, {0.90, 0.01}, {0.99, 0.001}}};
+  Summary summary{Summary::Quantiles{
+      {0.50, 0.05, "0.50"}, {0.90, 0.01, "0.90"}, {0.99, 0.001, "0.99"}}};
+  
   auto metric = summary.Collect();
   auto s = metric.summary;
   ASSERT_EQ(s.quantile.size(), 3U);
-  EXPECT_DOUBLE_EQ(s.quantile.at(0).quantile, 0.5);
-  EXPECT_DOUBLE_EQ(s.quantile.at(1).quantile, 0.9);
-  EXPECT_DOUBLE_EQ(s.quantile.at(2).quantile, 0.99);
+  EXPECT_EQ(s.quantile.at(0).quantile, "0.50");
+  EXPECT_EQ(s.quantile.at(1).quantile, "0.90");
+  EXPECT_EQ(s.quantile.at(2).quantile, "0.99");
 }
 
 TEST(SummaryTest, quantile_values) {

--- a/core/tests/text_serializer_test.cc
+++ b/core/tests/text_serializer_test.cc
@@ -117,8 +117,13 @@ TEST_F(TextSerializerTest, shouldSerializeSummary) {
   EXPECT_THAT(
       serialized,
       testing::HasSubstr(
-          name + "{quantile=\"0.50000000000000000\"} 0.0000000000000000"));
-}
+          name + "{quantile=\"0.50\""));
 
+  EXPECT_THAT(
+      serialized,
+      testing::HasSubstr(
+          "} 0.000"));
+
+}
 }  // namespace
 }  // namespace prometheus


### PR DESCRIPTION
add summary quantile label support, and with default precision
scope_duration_ms{instance="localhost:7777",job="processrun",module="UploadRunDataToS3",**quantile="0.98999999999999999"**} 
can change to **quantile="p99"** or quantile="0.99" default if not set lable name for quantile